### PR TITLE
Add the INTERNET permission to connect to PoE devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature android:name="android.hardware.usb.host" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"


### PR DESCRIPTION
We need to add the INTERNET permission to our app's AndroidManifest.xml file to connect to PoE devices. This allows network access and communication with external devices, enabling us to control and monitor PoE devices.

Adding the INTERNET permission is necessary for complete app functionality and a better user experience.